### PR TITLE
feat: enforce conventional commits standard

### DIFF
--- a/.github/workflows/commit-police.yml
+++ b/.github/workflows/commit-police.yml
@@ -1,0 +1,17 @@
+name: Commit Police
+
+on:
+  pull_request:
+    branches: [ master ]
+  push:
+    branches:    
+      - '*'
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: webiny/action-conventional-commits@v1.0.5


### PR DESCRIPTION
This Github action would enforce standards specified under https://www.conventionalcommits.org/en/v1.0.0/ 